### PR TITLE
Adds tests and modifies h5py as optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,12 @@ env:
         - NUMPY_VERSION=1.9
         - SCIPY_VERSION=0.17.0
         - ASTROPY_VERSION=stable
-        - H5PY_VERSION=2.5.0
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython numpy scipy h5py nose matplotlib'
+        - CONDA_DEPENDENCIES='Cython numpy scipy nose matplotlib'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,13 @@ env:
         - NUMPY_VERSION=1.9
         - SCIPY_VERSION=0.17.0
         - ASTROPY_VERSION=stable
+        - H5PY_VERSION=2.5.0
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython numpy scipy nose matplotlib'
+        - CONDA_DEPENDENCIES='Cython numpy scipy h5py nose matplotlib'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "scipy h5py numpy nose astropy matplotlib"
+        CONDA_DEPENDENCIES: "scipy numpy nose astropy matplotlib"
         PIP_DEPENDENCIES: ""
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "scipy numpy nose astropy matplotlib"
+        CONDA_DEPENDENCIES: "scipy numpy nose h5py astropy matplotlib"
         PIP_DEPENDENCIES: ""
 
     matrix:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ scipy
 matplotlib
 emcee
 corner
-h5py

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division,
                         print_function)
 
-import h5py
 import numpy as np
 import logging
 import warnings
@@ -508,7 +507,13 @@ def write(input_, filename, format_='pickle', **kwargs):
         _save_pickle_object(input_, filename)
 
     elif format_ == 'hdf5':
-        _save_hdf5_object(input_, filename)
+        try:
+            import h5py
+            _save_hdf5_object(input_, filename)
+
+        except ImportError:
+            utils.simon('h5py not installed, using pickle instead to save object.')
+            _save_pickle_object(input_, filename)
 
     elif format_ == 'ascii':
         _save_ascii_object(input_, filename, **kwargs)

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -302,7 +302,7 @@ def common_name(str1, str2, default='common'):
     logging.debug('common_name: %s %s -> %s' % (str1, str2, common_str))
     return common_str
 
-def _save_pickle_object(object, filename, **kwargs):
+def _save_pickle_object(object, filename):
     """
     Save a class object in pickle format.
 
@@ -314,15 +314,9 @@ def _save_pickle_object(object, filename, **kwargs):
     filename: str
         The file name to save to
     """
-    if 'save_as_dict' in locals():
-        # Get all object's attributes and its values in a dictionary format
-        items = vars(object)
-        with open(filename, "wb" ) as f:
-            pickle.dump(items, f)
 
-    else:
-        with open(filename, "wb" ) as f:
-            pickle.dump(object, f)
+    with open(filename, "wb" ) as f:
+        pickle.dump(object, f)
 
 def _retrieve_pickle_object(filename):
     """
@@ -335,8 +329,7 @@ def _retrieve_pickle_object(filename):
 
     Returns
     -------
-    data: class object or dictionary
-        Depends on the value of `save_as_dict`
+    data: class object
     """
     with open(filename, "rb" ) as f:
         return pickle.load(f)
@@ -509,13 +502,10 @@ def write(input_, filename, format_='pickle', **kwargs):
         name of the file to be created.
     format_: str
         pickle, hdf5, ascii ...
-
-    save_as_dict: boolean
-        Set to 'False' if intention is to store input as class object.
     """
 
     if format_ == 'pickle':
-        _save_pickle_object(input_, filename, **kwargs)
+        _save_pickle_object(input_, filename)
 
     elif format_ == 'hdf5':
         _save_hdf5_object(input_, filename)

--- a/stingray/io.py
+++ b/stingray/io.py
@@ -19,11 +19,16 @@ from .gti import  _get_gti_from_extension, load_gtis
 try:
     # Python 2
     import cPickle as pickle
-
 except:
     # Python 3
     import pickle
 
+_H5PY_INSTALLED = True
+
+try:
+    import h5py 
+except:
+    _H5PY_INSTALLED = False
 
 def get_file_extension(fname):
     """Get the extension from the file name."""
@@ -507,11 +512,10 @@ def write(input_, filename, format_='pickle', **kwargs):
         _save_pickle_object(input_, filename)
 
     elif format_ == 'hdf5':
-        try:
-            import h5py
+        if _H5PY_INSTALLED:
             _save_hdf5_object(input_, filename)
 
-        except ImportError:
+        else:
             utils.simon('h5py not installed, using pickle instead to save object.')
             _save_pickle_object(input_, filename)
 
@@ -537,7 +541,10 @@ def read(filename, format_='pickle', **kwargs):
         return _retrieve_pickle_object(filename)
 
     elif format_ == 'hdf5':
-        return _retrieve_hdf5_object(filename, **kwargs)
+        if _H5PY_INSTALLED:
+            return _retrieve_hdf5_object(filename)
+        else:
+            utils.simon('h5py not installed, cannot read an hdf5 object.')
 
     elif format_ == 'ascii':
         return _retrieve_ascii_object(filename, **kwargs)

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -608,9 +608,6 @@ class Lightcurve(object):
 
         format_: str
             Available options are 'pickle', 'hdf5', 'ascii'
-
-        save_as_dict: boolean, default 'False'
-            Applies only when the format_ is pickle.
         """
 
         if format_ == 'ascii':
@@ -618,7 +615,7 @@ class Lightcurve(object):
               filename, format_, fmt=["%s", "%s"])
 
         elif format_ == 'pickle':
-            io.write(self, filename, format_, **kwargs)
+            io.write(self, filename, format_)
 
         elif format_ == 'hdf5':
             io.write(self, filename, format_)

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -5,7 +5,6 @@ import os
 
 from astropy.tests.helper import pytest
 
-
 from ..io import read, write
 from ..io import ref_mjd
 from ..io import high_precision_keyword_read
@@ -79,14 +78,14 @@ class TestIOReadWrite(object):
     def test_operation(self):
         return self.number * 10
 
-H5PY_INSTALLED = True
+_H5PY_INSTALLED = True
 
 try:
     import h5py
 except ImportError:
-    H5PY_INSTALLED = False
+    _H5PY_INSTALLED = False
 
-skip_condition = pytest.mark.skipif(not H5PY_INSTALLED,
+skip_condition = pytest.mark.skipif(not _H5PY_INSTALLED,
     reason = "H5PY not installed.")
 
 class TestFileFormats(object):

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -70,50 +70,45 @@ class TestIO(object):
 class TestIOReadWrite(object):
     """A class to test all the read and write functions."""
     def __init__(self):
-        self.x = 10
-        self.y = np.array([1,2,3])
+        self.number = 10
+        self.str = 'Test'
+        self.list = [1,2,3]
+        self.array = np.array([1,2,3])
+        self.long_number = np.longdouble(1)
+        self.long_array = np.longdouble([1,2,3])
 
     def test_operation(self):
-        return self.x * 10
+        return self.number * 10
 
 
 class TestFileFormats(object):
 
-    def test_pickle_with_class_objects(self):
+    def test_pickle_read_write(self):
         """Test pickle object writing and reading."""
         test_object = TestIOReadWrite()
         write(test_object, filename='test.pickle', format_='pickle')
         assert read('test.pickle', 'pickle') is not None
         os.remove('test.pickle')
 
-    def test_pickle_with_dict_objects(self):
-        """Test pickle object writing and reading."""
-        test_object = TestIOReadWrite()
-        write(test_object, filename='test.pickle', format_='pickle', save_as_dict=True)
-        assert read('test.pickle', 'pickle') is not None
-        os.remove('test.pickle')
-
-    def test_pickle_attributes_with_class_objects(self):
+    def test_pickle_attributes(self):
         """Test if pickle maintains class object attributes."""
         test_object = TestIOReadWrite()
         write(test_object, filename='test.pickle', format_='pickle')
-        assert read('test.pickle', 'pickle').x == test_object.x
-        assert (read('test.pickle', 'pickle').y == test_object.y).all()
-        os.remove('test.pickle')
-
-    def test_pickle_attributes_with_dict_objects(self):
-        """Test if pickle maintains class object attributes."""
-        test_object = TestIOReadWrite()
-        write(test_object, 'test.pickle', 'pickle', save_as_dict=True)
-        assert read('test.pickle', 'pickle').x == test_object.x
-        assert (read('test.pickle', 'pickle').y == test_object.y).all()
+        rec_object = read('test.pickle', 'pickle')
+        assert rec_object.number == test_object.number
+        assert rec_object.str == test_object.str
+        assert rec_object.list == test_object.list
+        assert (rec_object.array == test_object.array).all()
+        assert rec_object.long_number == test_object.long_number
+        assert (rec_object.long_array == test_object.long_array).all()
+        
         os.remove('test.pickle')
 
     def test_pickle_functions(self):
         """Test if pickle maintains class methods."""
         test_object = TestIOReadWrite()
         write(test_object,'test.pickle', 'pickle')
-        assert read('test.pickle', 'pickle').test_operation() == test_object.x * 10
+        assert read('test.pickle', 'pickle').test_operation() == test_object.number * 10
         os.remove('test.pickle')
 
     def test_hdf5_write(self):
@@ -133,9 +128,13 @@ class TestFileFormats(object):
         """Test if hdf5 stored data is properly recovered."""
         test_object = TestIOReadWrite()
         write(test_object, 'test.hdf5', 'hdf5')
-        data = read('test.hdf5','hdf5')
-        assert data['x'] == test_object.x
-        assert (data['y'] == np.array(test_object.y)).all()
+        rec_object = read('test.hdf5','hdf5')
+        assert rec_object['number'] == test_object.number
+        assert rec_object['str'] == test_object.str
+        assert (rec_object['list'] == test_object.list).all()
+        assert (rec_object['array'] == np.array(test_object.array)).all()
+        assert rec_object['long_number'] == test_object.long_number
+        assert (rec_object['long_array'] == np.array(test_object.long_array)).all()
         os.remove('test.hdf5')
 
     def test_save_ascii(self):

--- a/stingray/tests/test_io.py
+++ b/stingray/tests/test_io.py
@@ -17,7 +17,6 @@ import warnings
 curdir = os.path.abspath(os.path.dirname(__file__))
 datadir = os.path.join(curdir, 'data')
 
-
 class TestIO(object):
 
     """Real unit tests."""
@@ -80,6 +79,15 @@ class TestIOReadWrite(object):
     def test_operation(self):
         return self.number * 10
 
+H5PY_INSTALLED = True
+
+try:
+    import h5py
+except ImportError:
+    H5PY_INSTALLED = False
+
+skip_condition = pytest.mark.skipif(not H5PY_INSTALLED,
+    reason = "H5PY not installed.")
 
 class TestFileFormats(object):
 
@@ -111,12 +119,14 @@ class TestFileFormats(object):
         assert read('test.pickle', 'pickle').test_operation() == test_object.number * 10
         os.remove('test.pickle')
 
+    @skip_condition
     def test_hdf5_write(self):
         """Test write functionality of hdf5."""
         test_object = TestIOReadWrite()
         write(test_object, 'test.hdf5', 'hdf5')
         os.remove('test.hdf5')
 
+    @skip_condition
     def test_hdf5_read(self):
         """Test read functionality of hdf5."""
         test_object = TestIOReadWrite()
@@ -124,6 +134,7 @@ class TestFileFormats(object):
         read('test.hdf5','hdf5')
         os.remove('test.hdf5')
 
+    @skip_condition
     def test_hdf5_data_recovery(self):
         """Test if hdf5 stored data is properly recovered."""
         test_object = TestIOReadWrite()

--- a/stingray/tests/test_lightcurve.py
+++ b/stingray/tests/test_lightcurve.py
@@ -1,12 +1,12 @@
 import os
 import warnings
 import matplotlib.pyplot as plt
+from astropy.tests.helper import pytest
 import numpy as np
 from nose.tools import raises
 from stingray import Lightcurve
 
 np.random.seed(20150907)
-
 
 class TestLightcurve(object):
 
@@ -366,6 +366,17 @@ class TestLightcurve(object):
         assert np.all(lc.counts == self.counts)
         os.remove('lc.pickle')
 
+    _H5PY_INSTALLED = True
+
+    try:
+        import h5py
+    except ImportError:
+        _H5PY_INSTALLED = False
+
+    skip_condition = pytest.mark.skipif(not _H5PY_INSTALLED,
+        reason = "H5PY not installed.")
+
+    @skip_condition
     def test_io_with_hdf5(self):
         lc = Lightcurve(self.times, self.counts)
         lc.write('lc.hdf5', format_='hdf5')


### PR DESCRIPTION
This PR:
- Adds tests for `np.longdouble`, `list` and `str`. 
- Modifies h5py as optional dependency and skips relevant tests if it is not installed.

NOT ready to be merged yet.
